### PR TITLE
docs(quick-setup): update setup, firebase, and iOS sections

### DIFF
--- a/Komodo-Wallet-Flutter-Quick-Setup.md
+++ b/Komodo-Wallet-Flutter-Quick-Setup.md
@@ -2,89 +2,112 @@
 
 Welcome to the Komodo Wallet Flutter setup guide\! This comprehensive guide will walk you through setting up, running, and deploying the Komodo Wallet application. Whether you're a developer getting started with the project or looking to deploy for production, we've got you covered.
 
-# Initial setup
+## Initial setup
 
-1. Install Flutter and switch to the latest stable release if you aren’t already using it.   
+1. Install Flutter and switch to the *3.22.3* release if you aren’t already using it.
    See Flutter’s official setup steps [here](https://docs.flutter.dev/get-started/install) or our setup steps [here](https://github.com/KomodoPlatform/komodo-wallet/blob/master/docs/INSTALL_FLUTTER.md) if you encounter issues.
 
    For developers: [Sidekick](https://github.com/fluttertools/sidekick) is an excellent tool for working with multiple Flutter versions on your machine.
 
-2. Install NPM and Node.js if you don’t already have them installed. Verify installation by running node \--version and npm \--version
+2. Install NPM and Node.js (LTS) if you don’t already have them installed. Preferrably LTS versions *20* or *18*, which are known to work. There are known issues with the current LTS release (*22*) Verify installation by running `node --version` and `npm --version`.
 
 3. Clone komodo-wallet repo: [https://github.com/KomodoPlatform/komodo-wallet.git](https://github.com/KomodoPlatform/komodo-wallet.git)
 
 4. Check out the *sia-wallet* branch.  
-     
-5. Clean the build folder and fetch dependencies by running the following:
 
-|  flutter clean && flutter pub get |
-| :---- |
+5. Clean the build folder and fetch dependencies by running the following. Coin icons and other assets are downloaded as part of the initial build, so the first build is expected to fail, but subsequent runs should succeed.
 
-# Running Locally
+```bash
+flutter clean && flutter pub get && flutter build web --release > /dev/null 2>&1 || true
+```
 
-Run the Flutter app with the standard Flutter build command. For example, flutter run \-d chrome or press the launch in your IDE if the launch configurations are set up.
+## Running Locally
+
+Run the Flutter app with the standard Flutter build command. For example, `flutter run -d chrome` or press the launch in your IDE if the launch configurations are set up.
 
 Do not commit the changes made under the *web* folder. You can mark them as excluded (or ignored) in your local git.
 
-# Building and Publishing
+## Building and Publishing
 
 1. Run the project locally per the section above, “*Running Locally*”, and verify that the app launches and you can create or login to a wallet.
 
-2. Clear any existing builds and compile a fresh one
+2. Clear any existing builds and compile a fresh one. The build process is run twice in case new assets are downloaded during the first run, which would cause the build to fail - requiring a second run to succeed.
 
-| flutter clean && flutter pub get && flutter build web \--release  |
-| :---- |
+```bash
+flutter clean && flutter pub get && flutter build web --release || flutter build web --release
+```
 
 ### Deploying to web hosting
 
 The *build/web* folder can be deployed to your preferred static web-hosting service. Alternatively, you can follow the steps below to set up and deploy to a Firebase Hosting project (free).
 
-### Deploying to Firebase:
+### Deploying to Firebase
 
 1. Create a new Firebase project at [https://console.firebase.google.com](https://console.firebase.google.com).
 
 2. Install Firebase CLI
 
-| npm install \-g firebase-tools |
-| :---- |
+   ```bash
+   npm install -g firebase-tools
+   ```
 
 3. Login to Firebase
 
-| firebase login |
-| :---- |
+   ```bash
+   firebase login
+   ```
 
-4. In your project folder, run Set up your project. Ensure “Hosting” and (optionally)  “Analytics” are selected. 
+4. Create a Firebase project and add it as an alias (via the [Console](https://docs.appmachine.com/app-details/firebase/create-firebase-project) or the [CLI](https://firebase.google.com/docs/cli#management-commands)).
+   1. (Optional) Create a project via the Firebase CLI if you don’t already have one.
 
-| firebase init |
-| :---- |
+      ```bash
+      firebase projects:create <unique project name>
+      ```
 
-   1. Select services you need (at minimum, select "Hosting")  
-   2. Choose your Firebase project  
-   3. *Detected an existing Flutter Web codebase in the current directory, should we use this?*: **Yes**  
-   4. Select your preferred region for server-side content. Note: The application does not use this, but you may need the functionality in the future.
+   2. Select the  Firebase project that you want to use, and add it as an alias.
 
-   5. *Set up automatic builds and deploys with GitHub?*: **No**
+      ```bash
+      firebase use --add
+      ```
 
-5. Deploy to Firebase
+5. Configure Firebase Hosting in the project root directory:
 
-| firebase deploy |
-| :---- |
+   ```bash
+   firebase init hosting
+   ```
 
-6. Your app will be live. Check the terminal for the link to access the site; alternatively, check the Firebase Console website.
+   1. What do you want to use as your public directory: `build/web`
+   2. Configure as a single-page app (rewrite all urls to /index.html)?: `y`
+   3. Set up automatic builds and deployws with GitHub?: `N`
+   4. File `build/web/index.html` already exists. Overwrite? `N`
 
-7. (Optional) Configure a custom domain: If you wish to host the site using your domain, follow the steps [here](https://firebase.google.com/docs/hosting/custom-domain). 
+6. (Optional) Test locally with `firebase serve`:
 
-# Setup after checking out a new branch:
+   ```bash
+   firebase serve --only hosting
+   ```
+
+7. Deploy to Firebase
+
+   ```bash
+   firebase deploy --only hosting
+   ```
+
+8. Your app will be live. Check the terminal for the link to access the site; alternatively, check the Firebase Console website. You might need to change the site name in `firebase.json` in the project root if there are conflicts.
+
+9. (Optional) Configure a custom domain: If you wish to host the site using your domain, follow the steps [here](https://firebase.google.com/docs/hosting/custom-domain).
+
+## Setup after checking out a new branch
 
 1. Terminate the build session.  
-2. Run flutter clean   
+2. Run flutter clean
 3. Run flutter pub get  
 4. Build/run the application as per the “Running Locally” section.
 
-# Steps for initial iOS setup:
+## Steps for initial iOS setup
 
 TODO
 
-# Troubleshooting
+## Troubleshooting
 
 Please provide feedback on any issues you encounter so we can assist you in resolving them by opening a [GitHub Issue](https://github.com/KomodoPlatform/komodo-wallet/issues/new?assignees=&labels=dev&projects=&template=dev.md&title=). This section will be updated to document them for others experiencing the same problem.

--- a/Komodo-Wallet-Flutter-Quick-Setup.md
+++ b/Komodo-Wallet-Flutter-Quick-Setup.md
@@ -9,13 +9,13 @@ Welcome to the Komodo Wallet Flutter setup guide\! This comprehensive guide will
 
    For developers: [Sidekick](https://github.com/fluttertools/sidekick) is an excellent tool for working with multiple Flutter versions on your machine.
 
-2. Install NPM and Node.js (LTS) if you don’t already have them installed. Preferrably LTS versions *20* or *18*, which are known to work. There are known issues with the current LTS release (*22*) Verify installation by running `node --version` and `npm --version`.
+2. Install NPM and Node.js, if you don’t already have them installed. Preferrably LTS versions *v20* or *v18*, which are known to work. There are known issues with the current *v22.** LTS release. Verify installation by running `node --version` and `npm --version`.
 
 3. Clone komodo-wallet repo: [https://github.com/KomodoPlatform/komodo-wallet.git](https://github.com/KomodoPlatform/komodo-wallet.git)
 
 4. Check out the *sia-wallet* branch.  
 
-5. Clean the build folder and fetch dependencies by running the following. Coin icons and other assets are downloaded as part of the initial build, so the first build is expected to fail, but subsequent runs should succeed.
+5. Clean the build folder and fetch dependencies by running the following. Coin icons and other assets are downloaded as part of the initial build, so it is expected to fail, but subsequent builds should succeed.
 
 ```bash
 flutter clean && flutter pub get && flutter build web --release > /dev/null 2>&1 || true
@@ -43,7 +43,7 @@ The *build/web* folder can be deployed to your preferred static web-hosting serv
 
 ### Deploying to Firebase
 
-1. Create a new Firebase project at [https://console.firebase.google.com](https://console.firebase.google.com).
+1. Create a new Firebase project at [https://console.firebase.google.com](https://console.firebase.google.com). Alternatively, do this later via the [Firebase CLI](https://firebase.google.com/docs/cli#management-commands).
 
 2. Install Firebase CLI
 
@@ -57,14 +57,7 @@ The *build/web* folder can be deployed to your preferred static web-hosting serv
    firebase login
    ```
 
-4. Create a Firebase project and add it as an alias (via the [Console](https://docs.appmachine.com/app-details/firebase/create-firebase-project) or the [CLI](https://firebase.google.com/docs/cli#management-commands)).
-   1. (Optional) Create a project via the Firebase CLI if you don’t already have one.
-
-      ```bash
-      firebase projects:create <unique project name>
-      ```
-
-   2. Select the  Firebase project that you want to use, and add it as an alias.
+4. Add the Firebase project created in step 1. as an alias. Select the project you wish to use when prompted.
 
       ```bash
       firebase use --add
@@ -78,7 +71,7 @@ The *build/web* folder can be deployed to your preferred static web-hosting serv
 
    1. What do you want to use as your public directory: `build/web`
    2. Configure as a single-page app (rewrite all urls to /index.html)?: `y`
-   3. Set up automatic builds and deployws with GitHub?: `N`
+   3. Set up automatic builds and deploys with GitHub?: `N`
    4. File `build/web/index.html` already exists. Overwrite? `N`
 
 6. (Optional) Test locally with `firebase serve`:

--- a/Komodo-Wallet-Flutter-Quick-Setup.md
+++ b/Komodo-Wallet-Flutter-Quick-Setup.md
@@ -104,9 +104,31 @@ The *build/web* folder can be deployed to your preferred static web-hosting serv
 3. Run flutter pub get  
 4. Build/run the application as per the “Running Locally” section.
 
-## Steps for initial iOS setup
+## Steps for initial iOS setup (macOS only)
 
-TODO
+1. Install the latest version of [ruby](https://www.ruby-lang.org/en/documentation/installation/)
+
+   ```bash
+   brew install ruby
+   ```
+
+2. Install the lates version of [cocoapods](https://cocoapods.org/)
+
+   ```bash
+   sudo gem install cocoapods
+   ```
+
+3. Navigate to the *ios* folder in the project root and run the following command
+
+   ```bash
+   pod install
+   ```
+
+4. Build the iOS application (from the project root)
+
+   ```bash
+   flutter build ios --release --no-codesign
+   ```
 
 ## Troubleshooting
 


### PR DESCRIPTION
Updated the quick setup guide thanks to feedback from @AndrewDelaney

- Add the pinned Flutter version, *3.22.3*, to the initial setup section
- Add the recommended Node.js versions to the initial setup section
- Add notes about the build process having to run twice to download assets
- Update the firebase setup steps 
- Complete the initial iOS setup section